### PR TITLE
Make pinger struct public

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/iverly/go-mcping v1.0.1 h1:Gmza80C+CZw1XjDNWDdPg0lARlUqR5Q2/uGuEcReSZE=
+github.com/iverly/go-mcping v1.0.1/go.mod h1:OTdb13yxI0zg1VKs7G53T43N2hAduaPeUcY+PbP608g=
 github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e h1:ZZCvgaRDZg1gC9/1xrsgaJzQUCQgniKtw0xjWywWAOE=
 github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e/go.mod h1:+rHyWac2R9oAZwFe1wGY2HBzFJJy++RHBg1cU23NkD8=

--- a/mcping/pinger.go
+++ b/mcping/pinger.go
@@ -11,40 +11,40 @@ import (
 	"github.com/iverly/go-mcping/latency"
 )
 
-type pinger struct {
+type Pinger struct {
 	DnsResolver types.DnsResolver
 	Latency     types.Latency
 }
 
 // Create a new Minecraft Pinger
-func NewPinger() *pinger {
+func NewPinger() *Pinger {
 	var resolver types.DnsResolver
 	resolver = dns.NewResolver()
-	return &pinger{DnsResolver: resolver}
+	return &Pinger{DnsResolver: resolver}
 }
 
 // Create a new Minecraft Pinger with a custom DNS resolver
-func NewPingerWithDnsResolver(dnsResolver types.DnsResolver) *pinger {
-	return &pinger{DnsResolver: dnsResolver}
+func NewPingerWithDnsResolver(dnsResolver types.DnsResolver) *Pinger {
+	return &Pinger{DnsResolver: dnsResolver}
 }
 
 // Ping and get information from an host and port, default timeout: 3s
 // Return a pointer to types.PingResponse or an error
 //
-// Error is thrown when the host is unreachable or the data received are incorrect
+// # Error is thrown when the host is unreachable or the data received are incorrect
 //
-// Example: pinger.Ping("play.hypixel.net", 25565)
-func (p *pinger) Ping(host string, port uint16) (*types.PingResponse, error) {
+// Example: Pinger.Ping("play.hypixel.net", 25565)
+func (p *Pinger) Ping(host string, port uint16) (*types.PingResponse, error) {
 	return p.PingWithTimeout(host, port, 3*time.Second)
 }
 
 // Ping and get information from an host and port with a custom timeout
 // Return a pointer to types.PingResponse or an error
 //
-// Error is thrown when the host is unreachable or the data received are incorrect
+// # Error is thrown when the host is unreachable or the data received are incorrect
 //
 // Example: pinger.Ping("play.hypixel.net", 25565, 5 * time.Second)
-func (p *pinger) PingWithTimeout(host string, port uint16, timeout time.Duration) (*types.PingResponse, error) {
+func (p *Pinger) PingWithTimeout(host string, port uint16, timeout time.Duration) (*types.PingResponse, error) {
 	resolve, hostSRV, portSRV := p.DnsResolver.SRVResolve(host)
 	if resolve {
 		host = hostSRV


### PR DESCRIPTION
If the `Pinger` struct is public, we can pass it to func args or another struct